### PR TITLE
Escape dollar signs in record field labels

### DIFF
--- a/Resume/Basic.dhall
+++ b/Resume/Basic.dhall
@@ -1,5 +1,6 @@
 { Type =
-    { basics : Optional (./Basics.dhall).Type
+    { `$schema` : Optional Text
+    , basics : Optional (./Basics.dhall).Type
     , work : Optional (List (./Work.dhall).Type)
     , volunteer : Optional (List (./Volunteer.dhall).Type)
     , education : Optional (List (./Education.dhall).Type)
@@ -11,9 +12,11 @@
     , interests : Optional (List (./Interest.dhall).Type)
     , references : Optional (List (./Reference.dhall).Type)
     , projects : Optional (List (./Project.dhall).Type)
+    , meta : Optional (./Meta.dhall).Type
     }
 , default =
-  { basics = None (./Basics.dhall).Type
+  { `$schema` = None Text
+  , basics = None (./Basics.dhall).Type
   , work = None (List (./Work.dhall).Type)
   , volunteer = None (List (./Volunteer.dhall).Type)
   , education = None (List (./Education.dhall).Type)
@@ -25,5 +28,6 @@
   , interests = None (List (./Interest.dhall).Type)
   , references = None (List (./Reference.dhall).Type)
   , projects = None (List (./Project.dhall).Type)
+  , meta = None (./Meta.dhall).Type
   }
 }

--- a/Resume/Meta.dhall
+++ b/Resume/Meta.dhall
@@ -1,0 +1,8 @@
+{ Type =
+    { canonical : Optional Text
+    , version : Optional Text
+    , lastModified : Optional Text
+    }
+, default =
+  { canonical = None Text, version = None Text, lastModified = None Text }
+}


### PR DESCRIPTION
`make update && make format` does not work as is on `main`, because the schema file includes the `$schema` field which is not valid in Dhall. ~The schema also includes a `meta` section, which is not relevant for the Dhall sources. This PR ignores both of these fields during the type generation, and also regenerates the types from the current JSON Resume schema.~

This PR fixes this by escaping the fields that contain `$` by enclosing them with backticks, as explained in the [Dhall documentation](https://docs.dhall-lang.org/tutorials/Language-Tour.html#names); and also regenerates the types from the current JSON Resume schema. 