### PR TITLE
Parse ISO8601 type as `Date`

### DIFF
--- a/Resume/Award.dhall
+++ b/Resume/Award.dhall
@@ -1,12 +1,12 @@
 { Type =
     { title : Optional Text
-    , date : Optional Text
+    , date : Optional Date
     , awarder : Optional Text
     , summary : Optional Text
     }
 , default =
   { title = None Text
-  , date = None Text
+  , date = None Date
   , awarder = None Text
   , summary = None Text
   }

--- a/Resume/Education.dhall
+++ b/Resume/Education.dhall
@@ -3,8 +3,8 @@
     , url : Optional Text
     , area : Optional Text
     , studyType : Optional Text
-    , startDate : Optional Text
-    , endDate : Optional Text
+    , startDate : Optional Date
+    , endDate : Optional Date
     , score : Optional Text
     , courses : Optional (List Text)
     }
@@ -13,8 +13,8 @@
   , url = None Text
   , area = None Text
   , studyType = None Text
-  , startDate = None Text
-  , endDate = None Text
+  , startDate = None Date
+  , endDate = None Date
   , score = None Text
   , courses = None (List Text)
   }

--- a/Resume/Project.dhall
+++ b/Resume/Project.dhall
@@ -3,8 +3,8 @@
     , description : Optional Text
     , highlights : Optional (List Text)
     , keywords : Optional (List Text)
-    , startDate : Optional Text
-    , endDate : Optional Text
+    , startDate : Optional Date
+    , endDate : Optional Date
     , url : Optional Text
     , roles : Optional (List Text)
     , entity : Optional Text
@@ -15,8 +15,8 @@
   , description = None Text
   , highlights = None (List Text)
   , keywords = None (List Text)
-  , startDate = None Text
-  , endDate = None Text
+  , startDate = None Date
+  , endDate = None Date
   , url = None Text
   , roles = None (List Text)
   , entity = None Text

--- a/Resume/Publication.dhall
+++ b/Resume/Publication.dhall
@@ -1,14 +1,14 @@
 { Type =
     { name : Optional Text
     , publisher : Optional Text
-    , releaseDate : Optional Text
+    , releaseDate : Optional Date
     , url : Optional Text
     , summary : Optional Text
     }
 , default =
   { name = None Text
   , publisher = None Text
-  , releaseDate = None Text
+  , releaseDate = None Date
   , url = None Text
   , summary = None Text
   }

--- a/Resume/Volunteer.dhall
+++ b/Resume/Volunteer.dhall
@@ -2,8 +2,8 @@
     { organization : Optional Text
     , position : Optional Text
     , url : Optional Text
-    , startDate : Optional Text
-    , endDate : Optional Text
+    , startDate : Optional Date
+    , endDate : Optional Date
     , summary : Optional Text
     , highlights : Optional (List Text)
     }
@@ -11,8 +11,8 @@
   { organization = None Text
   , position = None Text
   , url = None Text
-  , startDate = None Text
-  , endDate = None Text
+  , startDate = None Date
+  , endDate = None Date
   , summary = None Text
   , highlights = None (List Text)
   }

--- a/Resume/Work.dhall
+++ b/Resume/Work.dhall
@@ -4,8 +4,8 @@
     , description : Optional Text
     , position : Optional Text
     , url : Optional Text
-    , startDate : Optional Text
-    , endDate : Optional Text
+    , startDate : Optional Date
+    , endDate : Optional Date
     , summary : Optional Text
     , highlights : Optional (List Text)
     , skills : Optional (List Text)
@@ -17,8 +17,8 @@
   , description = None Text
   , position = None Text
   , url = None Text
-  , startDate = None Text
-  , endDate = None Text
+  , startDate = None Date
+  , endDate = None Date
   , summary = None Text
   , highlights = None (List Text)
   , skills = None (List Text)

--- a/examples/demo.dhall
+++ b/examples/demo.dhall
@@ -10,6 +10,7 @@ in Resume.Basic::{
         Resume.Work::{
             , name = Some "Foo"
             , location = Some "Earth"
+            , startDate = Some 2024-01-27
             , salaries = Some [
                 Resume.Salary::{
                     amount = 2000

--- a/scripts/schemastore-to-dhall.py
+++ b/scripts/schemastore-to-dhall.py
@@ -60,7 +60,12 @@ def dhall_type(value: Property, name: str, types: Types, defs: Defs) -> Optional
         value['type'] = [value['type']]
     if value.get("$ref"):
         ref = value['$ref'].split('/')[-1]
-        return dhall_type(defs[ref], ref, types, defs)
+        # This is not full-ISO8601, but a 'Date' should be sufficient
+        # for resume purposes
+        if ref == "iso8601":
+            _type = 'Date'
+        else:
+            return dhall_type(defs[ref], ref, types, defs)
     elif "object" in value["type"]:
         if all(map(lambda k: not value.get(k), ["properties", "patternProperties", "additionalProperties"])):
             return None


### PR DESCRIPTION
Currently, the date fields are represented as `Text` in Dhall types. This allows the construction of values that would be rejected by JSON Resume validators (e.g. `Jan. 2024`). With this PR, these are now parsed as `Date` types. `Date` type does not include time information, so this is not strictly ISO8601, but I would argue that this is fine for resume purposes.